### PR TITLE
Fix scroll

### DIFF
--- a/demo/Demo.jsx
+++ b/demo/Demo.jsx
@@ -1,4 +1,5 @@
-import FilterList from "../src/components/FilterList";
+import ApiList from "../src/components/ApiList";
+import { Button } from "@baltimorecounty/dotgov-components";
 import React from "react";
 
 const filters = [
@@ -15,11 +16,18 @@ const filters = [
 const Demo = (props) => {
   return (
     <div className="demo">
-      <FilterList
-        title="News"
-        filters={filters}
-        apiEndpoint="http://localhost:54727/api/hub/structuredContent/news"
-        renderItem={({ title, articleSummary }) => (
+      <ApiList
+        endpoint="http://localhost:54727/api/hub/structuredContent/news?recordsPerPage=5"
+        title="Sample News"
+        renderLoadMoreButton={({ isFetching, onClick, isFetchingMore }) => (
+          <Button
+            type="button"
+            disabled={isFetching}
+            text={isFetchingMore ? "Loading more..." : "Load More"}
+            onClick={onClick}
+          />
+        )}
+        renderItem={({ title, articleSummary }, index) => (
           <div
             style={{
               border: "1px solid #e0e0e0",
@@ -27,7 +35,9 @@ const Demo = (props) => {
               marginBottom: "10px",
             }}
           >
-            <h2>{title}</h2>
+            <h2>
+              {index} - {title}
+            </h2>
             <p>{articleSummary}</p>
           </div>
         )}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/react-filter-list",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A react component that provides standard way to show and filter lists",
   "main": "dist/index.js",
   "module": "dist/index.em.js",

--- a/src/components/ApiList.jsx
+++ b/src/components/ApiList.jsx
@@ -25,7 +25,6 @@ const ApiList = ({
 }) => {
   const {
     data,
-    error,
     isFetching,
     isFetchingMore,
     fetchMore,
@@ -42,12 +41,16 @@ const ApiList = ({
     }
   );
 
-  if (isFetching) {
+  if (status === "loading") {
     return <p>Loading {title}...</p>;
   }
 
-  if (error) {
-    return <p>Something went wrong loading {title}.</p>;
+  if (status === "error") {
+    return (
+      <p>
+        Something went wrong with {title}. Please try again in a few minutes.
+      </p>
+    );
   }
 
   const { metaData: { totalRecords = 0 } = {} } = data[0] || {};

--- a/src/components/ApiList.jsx
+++ b/src/components/ApiList.jsx
@@ -14,8 +14,8 @@ import { useInfiniteQuery } from "react-query";
  * @param {string} optionalParams.endpoint endpoint passed to the list from props
  * @param {string} loadMoreEndpoint endpoint passed from api list when the load more button is selected
  */
-const fetchList = (key, { endpoint }, loadMoreEndpoint) =>
-  fetch(loadMoreEndpoint || endpoint).then((res) => res.json());
+const fetchList = (key, { endpoint }, nextLink) =>
+  fetch(nextLink || endpoint).then((res) => res.json());
 
 const ApiList = ({
   title,


### PR DESCRIPTION
When Clicking Load More,

> you don't retain your position on the page: the scroll position jumps up to the middle of the summaries.

per QA

This was recreateable and had something to do with how we were checking loading and error states.

After reading the [react-query doc](https://github.com/tannerlinsley/react-query#queries) this has been adjusted to match their usage.