### PR TITLE
Fix Issue with Load More Scroll Position

### DIFF
--- a/demo/Demo.jsx
+++ b/demo/Demo.jsx
@@ -18,7 +18,7 @@ const Demo = (props) => {
       <FilterList
         title="News"
         filters={filters}
-        apiEndpoint="http://localhost:54727/api/hub/structuredContent/news"
+        apiEndpoint="{yourNewsEndpointGoesHere}"
         renderItem={({ title, articleSummary }) => (
           <div
             style={{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/react-filter-list",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A react component that provides standard way to show and filter lists",
   "main": "dist/index.js",
   "module": "dist/index.em.js",

--- a/src/components/ApiList.jsx
+++ b/src/components/ApiList.jsx
@@ -25,7 +25,6 @@ const ApiList = ({
 }) => {
   const {
     data,
-    error,
     isFetching,
     isFetchingMore,
     fetchMore,

--- a/src/components/ApiList.jsx
+++ b/src/components/ApiList.jsx
@@ -42,12 +42,16 @@ const ApiList = ({
     }
   );
 
-  if (isFetching) {
+  if (status === "loading") {
     return <p>Loading {title}...</p>;
   }
 
-  if (error) {
-    return <p>Something went wrong loading {title}.</p>;
+  if (status === "error") {
+    return (
+      <p>
+        Something went wrong with {title}. Please try again in a few minutes.
+      </p>
+    );
   }
 
   const { metaData: { totalRecords = 0 } = {} } = data[0] || {};


### PR DESCRIPTION
When Clicking Load More,

> you don't retain your position on the page: the scroll position jumps up to the middle of the summaries.

per QA

This was recreateable and had something to do with how we were checking loading and error states.

After reading the [react-query doc](https://github.com/tannerlinsley/react-query#queries) this has been adjusted to match their usage.