### PR TITLE
Collapse Filter Options Part 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/react-filter-list",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "A react component that provides standard way to show and filter lists",
   "main": "dist/index.js",
   "module": "dist/index.em.js",

--- a/public/index.html
+++ b/public/index.html
@@ -5,10 +5,30 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Page Title</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      .plus-text-icon,
+      .minus-text-icon {
+        position: relative;
+      }
+      .plus-text-icon:before,
+      .minus-text-icon:before {
+        display: inline-block;
+        margin-right: 5px;
+      }
+
+      .plus-text-icon:before {
+        content: "+";
+      }
+
+      .minus-text-icon:before {
+        content: "-";
+      }
+    </style>
   </head>
   <body>
     <h1>Package Name Examples</h1>
     <div id="root"></div>
+    <script src="//beta.baltimorecountymd.gov/sebin/z/l/dotgov-site.min.js"></script>
     <script src="demo.js"></script>
   </body>
 </html>

--- a/src/components/DefaultFilter.jsx
+++ b/src/components/DefaultFilter.jsx
@@ -1,27 +1,44 @@
-import { Checkbox, Collapse } from "@baltimorecounty/dotgov-components";
+import { Button, Checkbox, Collapse } from "@baltimorecounty/dotgov-components";
 
+import OptionsCollapse from "./OptionsCollapse";
 import React from "react";
 
 const DefaultFilter = ({
   filter: { targetApiField, displayName, options },
   onChange,
-}) => (
-  <Collapse id={targetApiField} header={displayName}>
-    {options.map(({ label, value, checked }) => {
-      const id = `${targetApiField}-${value.split(" ").join("-")}`;
-      return (
-        <Checkbox
-          key={`${id}-${checked}`}
-          id={id}
-          name={targetApiField}
+}) => {
+  const shouldCollapseOptions = options.length > 0;
+  let moreOptions;
+
+  if (shouldCollapseOptions) {
+    moreOptions = [...options].splice(5);
+  }
+
+  return (
+    <Collapse id={targetApiField} header={displayName}>
+      {options.slice(0, 5).map(({ label, value, checked }) => {
+        const id = `${targetApiField}-${value.split(" ").join("-")}`;
+        return (
+          <Checkbox
+            key={`${id}-${checked}`}
+            id={id}
+            name={targetApiField}
+            onChange={onChange}
+            label={label}
+            value={value}
+            checked={checked}
+          />
+        );
+      })}
+      {moreOptions.length > 0 && (
+        <OptionsCollapse
+          options={moreOptions}
           onChange={onChange}
-          label={label}
-          value={value}
-          checked={checked}
+          targetApiField={targetApiField}
         />
-      );
-    })}
-  </Collapse>
-);
+      )}
+    </Collapse>
+  );
+};
 
 export default DefaultFilter;

--- a/src/components/DefaultFilter.jsx
+++ b/src/components/DefaultFilter.jsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, Collapse } from "@baltimorecounty/dotgov-components";
+import { Checkbox, Collapse } from "@baltimorecounty/dotgov-components";
 
 import OptionsCollapse from "./OptionsCollapse";
 import React from "react";
@@ -30,7 +30,7 @@ const DefaultFilter = ({
           />
         );
       })}
-      {moreOptions.length > 0 && (
+      {shouldCollapseOptions && (
         <OptionsCollapse
           options={moreOptions}
           onChange={onChange}

--- a/src/components/OptionsCollapse.jsx
+++ b/src/components/OptionsCollapse.jsx
@@ -1,0 +1,59 @@
+import { Button, Checkbox } from "@baltimorecounty/dotgov-components";
+import React, { useState } from "react";
+
+const OptionsCollapse = ({
+  options = [],
+  targetApiField = "",
+  onChange = () => {},
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleToggleClick = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  const buttonStyles = {
+    paddingLeft: "0",
+    paddingRight: "0",
+  };
+
+  return (
+    <div>
+      {!isExpanded && (
+        <Button
+          className="dg_button-link plus-text-icon"
+          onClick={handleToggleClick}
+          text="Show More"
+          style={buttonStyles}
+        />
+      )}
+
+      {isExpanded && (
+        <>
+          {options.map(({ label, value, checked }) => {
+            const id = `${targetApiField}-${value.split(" ").join("-")}`;
+            return (
+              <Checkbox
+                key={`${id}-${checked}`}
+                id={id}
+                name={targetApiField}
+                onChange={onChange}
+                label={label}
+                value={value}
+                checked={checked}
+              />
+            );
+          })}
+          <Button
+            className="dg_button-link minus-text-icon"
+            onClick={handleToggleClick}
+            text="Show Less"
+            style={buttonStyles}
+          />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default OptionsCollapse;


### PR DESCRIPTION
Limits Filter Options to 5 visible options by default with a show more function to see all filters if hte user wants.

Note this does not account for filter ordering, and this is missing accessibility stuff, but should work for the demo.

A separate pr will address the ordering