### PR TITLE
Add ability to pass Static filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,24 @@ const filters = [
 | displayName    | string          | Value you want to display for users to view.                                                                                    |
 | options        | array (objects) | Contains an array of objects (label / value). Value is what you need to pass to the api, label is what you want the user to see |
 
+#### Static Filters
+
+A static filter can be added to the filter list if you always want that filter
+value you to be passed to the API request.
+
+In order to do that you must simply pass the `targetApiField` and `value` that
+you want to pass. For Example:
+
+```js
+{
+    targetApiField: "recordsPerPage",
+    value: 1000
+}
+```
+
+This can be added to the array of filters, but will not be displayed in teh
+application.
+
 ### Running the App
 
 Since the primary function of repository is to export the FilterList to npm, we
@@ -98,10 +116,13 @@ To run all tests use `npm test`
 
 To deploy this package to NPM:
 
-1. Ensure the package.json file has been updated with the newest version that you wish to publish
-2. [Create a release](https://github.com/baltimorecounty/react-filter-list/releases/new) using the version from step 1.
-3. A [Github Action](https://github.com/baltimorecounty/react-filter-list/actions?query=workflow%3A%22Release+to+NPM%22) will publish this to NPM once the release is published
-
+1. Ensure the package.json file has been updated with the newest version that
+   you wish to publish
+2. [Create a release](https://github.com/baltimorecounty/react-filter-list/releases/new)
+   using the version from step 1.
+3. A
+   [Github Action](https://github.com/baltimorecounty/react-filter-list/actions?query=workflow%3A%22Release+to+NPM%22)
+   will publish this to NPM once the release is published
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/react-filter-list",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A react component that provides standard way to show and filter lists",
   "main": "dist/index.js",
   "module": "dist/index.em.js",

--- a/src/common/Filters.js
+++ b/src/common/Filters.js
@@ -2,7 +2,8 @@ import { parse } from "query-string";
 
 /** Resets filter to default state. All options are unchecked */
 const resetFilter = (filter) => {
-  filter.options.map((option) => {
+  const { options = [] } = filter;
+  options.map((option) => {
     option.checked = false;
     return option;
   });
@@ -36,8 +37,9 @@ const updateFilters = (filters = [], queryStringFilters = {}) => {
 
     if (matchingFilter) {
       const urlValues = queryStringFilters[key].toLowerCase().split(",");
+      const { options = [] } = matchingFilter;
 
-      matchingFilter.options.map((option) => {
+      options.map((option) => {
         const { value = "" } = option;
         option.checked = urlValues.some(
           (urlValue = "") => value.toLowerCase() === urlValue.toLowerCase()

--- a/src/components/FilterList.jsx
+++ b/src/components/FilterList.jsx
@@ -35,21 +35,32 @@ const FilterList = ({
   staticContext,
   ...props
 }) => {
+  const staticFilterQueryString = filtersFromProps
+    .filter(({ value }) => value)
+    .map(({ targetApiField, value }) => `${targetApiField}=${value}`)
+    .join("&");
   const [filters, setFilters] = useState(() =>
     UpdateFilters(filtersFromProps, location.search)
   );
-  const [apiEndpoint, setApiEndpoint] = useState(() => defaultApiEndpoint);
+  const [apiEndpoint, setApiEndpoint] = useState(
+    () => defaultApiEndpoint + "?" + staticFilterQueryString
+  );
 
   useEffect(() => {
     setFilters((filters) => UpdateFilters(filters, location.search));
-    setApiEndpoint(defaultApiEndpoint + location.search);
+    setApiEndpoint(
+      defaultApiEndpoint +
+        location.search +
+        (location.search.indexOf("?") > -1 ? "&" : "?") +
+        staticFilterQueryString
+    );
   }, [location.search]);
 
   const updateQueryString = (filter) => {
     const [base, currentQueryString] = apiEndpoint.split("?");
     const queryString = UpdateQueryString({
       filter,
-      queryString: currentQueryString,
+      queryString: currentQueryString.replace(staticFilterQueryString, ""),
     });
 
     history.push(location.pathname + queryString);

--- a/src/components/Filters.jsx
+++ b/src/components/Filters.jsx
@@ -6,11 +6,13 @@ const Filters = ({
   renderFilter = () => {},
 }) => (
   <>
-    {filters.map((filter) => (
-      <div key={filter.targetApiField}>
-        {renderFilter(filter, handleFilterChange)}
-      </div>
-    ))}
+    {filters
+      .filter(({ options = [] }) => options.length > 0)
+      .map((filter) => (
+        <div key={filter.targetApiField}>
+          {renderFilter(filter, handleFilterChange)}
+        </div>
+      ))}
   </>
 );
 


### PR DESCRIPTION
Pass static filters to the API Calls. These filters will not be visible, but be applied to each API call.

A good example of this would be when you want to set the number of records to be greater than 10, but do not want the user to have control over this, which is a current use case we have in some scenarios.