### PR TITLE
Fix url double query strings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Page Title</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="https://kit.fontawesome.com/2475edd293.js"></script>
     <script src="//baltimorecountymd.gov/sebin/z/l/dotgov-site.min.js"></script>
     <style>
@@ -35,7 +36,6 @@
   <body>
     <h1>Package Name Examples</h1>
     <div id="root"></div>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="demo.js"></script>
   </body>
 </html>

--- a/src/components/FilterList.jsx
+++ b/src/components/FilterList.jsx
@@ -73,18 +73,18 @@ const FilterList = ({
   const buildDefaultEndPoint = () => {
     const dateFilter = "filterdate=" + filterDateValue;
     const staticFilter = "?" + staticFilterQueryString;
+    const endPointRoot = defaultApiEndpoint.split("?")[0];
     let newEndPoint;
-
     if (location.search.indexOf("?") > -1) {
-      newEndPoint = defaultApiEndpoint + location.search;
+      newEndPoint = endPointRoot + location.search;
     } else if (staticFilterQueryString && includeDateFilter) {
-      newEndPoint = defaultApiEndpoint + staticFilter + "&" + dateFilter;
+      newEndPoint = endPointRoot + staticFilter + "&" + dateFilter;
     } else if (staticFilterQueryString && !includeDateFilter) {
-      newEndPoint = defaultApiEndpoint + staticFilter;
+      newEndPoint = endPointRoot + staticFilter;
     } else if (!staticFilterQueryString && includeDateFilter) {
-      newEndPoint = defaultApiEndpoint + "?" + dateFilter;
+      newEndPoint = endPointRoot + "?" + dateFilter;
     } else {
-      newEndPoint = defaultApiEndpoint;
+      newEndPoint = endPointRoot;
     }
     return newEndPoint;
   };

--- a/src/components/FilterList.jsx
+++ b/src/components/FilterList.jsx
@@ -95,6 +95,7 @@ const FilterList = ({
 
   useEffect(() => {
     setFilters((filters) => UpdateFilters(filters, location.search));
+    setApiEndpoint(buildDefaultEndPoint());
   }, [location.search]);
 
   const updateQueryString = (filter) => {

--- a/src/components/FilterList.jsx
+++ b/src/components/FilterList.jsx
@@ -75,7 +75,9 @@ const FilterList = ({
     const staticFilter = "?" + staticFilterQueryString;
     let newEndPoint;
 
-    if (staticFilterQueryString && includeDateFilter) {
+    if (location.search.indexOf("?") > -1) {
+      newEndPoint = defaultApiEndpoint + location.search;
+    } else if (staticFilterQueryString && includeDateFilter) {
       newEndPoint = defaultApiEndpoint + staticFilter + "&" + dateFilter;
     } else if (staticFilterQueryString && !includeDateFilter) {
       newEndPoint = defaultApiEndpoint + staticFilter;
@@ -84,7 +86,6 @@ const FilterList = ({
     } else {
       newEndPoint = defaultApiEndpoint;
     }
-
     return newEndPoint;
   };
 
@@ -94,12 +95,6 @@ const FilterList = ({
 
   useEffect(() => {
     setFilters((filters) => UpdateFilters(filters, location.search));
-
-    if (location.search.indexOf("?") > -1) {
-      setApiEndpoint(defaultApiEndpoint + location.search);
-    } else {
-      setApiEndpoint(includeDateFilter ? apiEndpoint : defaultApiEndpoint);
-    }
   }, [location.search]);
 
   const updateQueryString = (filter) => {
@@ -176,6 +171,7 @@ const FilterList = ({
     history.push(location.pathname + "?" + queryString);
     setApiEndpoint(updatedUrl);
   };
+
   const clearFilter = () => {
     setIsClear(true);
     const [base, currentQueryString] = apiEndpoint.split("?");


### PR DESCRIPTION
Start with the base of the API URL (e.g. https://localhost:44387/api/Pets) before adding the querystrings (e.g. ?status=Adoptable&recordsPerPage=10) and perform all manipulations in the same if/else clause