### PR TITLE
Prevent default re-render on window focus that is causing unnecessary API calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/react-filter-list",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "A react component that provides standard way to show and filter lists",
   "main": "dist/index.js",
   "module": "dist/index.em.js",

--- a/src/components/ApiList.jsx
+++ b/src/components/ApiList.jsx
@@ -2,7 +2,7 @@ import "promise-polyfill/src/polyfill";
 import "whatwg-fetch";
 
 import React from "react";
-import { useInfiniteQuery } from "react-query";
+import { useInfiniteQuery, setFocusHandler } from "react-query";
 
 /**
  * Fetches list of items
@@ -14,7 +14,15 @@ import { useInfiniteQuery } from "react-query";
  * @param {string} loadMoreEndpoint endpoint passed from api list when the load more button is selected
  */
 const fetchList = (key, { endpoint }, loadMoreEndpoint) =>
-  fetch(loadMoreEndpoint || endpoint).then(res => res.json());
+  fetch(loadMoreEndpoint || endpoint).then((res) => res.json());
+
+// Default behavior of the FocusHandler is to re-render the component when the window
+// regains focus. This causes unnecessary extra API calls and introduces slowness.
+// Overriding behavior so it does nothing when the windows regains focus.
+// Reference: https://www.npmjs.com/package/react-query/v/2.4.3#custom-window-focus-event
+setFocusHandler(() => {
+  return () => {};
+});
 
 const ApiList = ({
   className,
@@ -22,7 +30,7 @@ const ApiList = ({
   endpoint,
   renderHeader = () => {},
   renderItem = () => {},
-  renderLoadMoreButton = () => {}
+  renderLoadMoreButton = () => {},
 }) => {
   const {
     data,
@@ -30,15 +38,16 @@ const ApiList = ({
     isFetchingMore,
     fetchMore,
     canFetchMore,
-    status
+    status,
   } = useInfiniteQuery(
     ["apiGET", { endpoint }],
     fetchList,
     {
-      getFetchMore: ({ metaData: { links = {} } = {} }, allGroups) => links.next
+      getFetchMore: ({ metaData: { links = {} } = {} }, allGroups) =>
+        links.next,
     },
     {
-      refetchOnWindowFocus: false
+      refetchOnWindowFocus: false,
     }
   );
 
@@ -66,7 +75,7 @@ const ApiList = ({
       <div className={className}>
         {data.map((group, i) => (
           <React.Fragment key={i}>
-            {group.records.map(record => (
+            {group.records.map((record) => (
               <React.Fragment key={record.id}>
                 {renderItem(record)}
               </React.Fragment>
@@ -78,7 +87,7 @@ const ApiList = ({
         renderLoadMoreButton({
           isFetching,
           isFetchingMore,
-          onClick: handleLoadMoreClick
+          onClick: handleLoadMoreClick,
         })}
     </div>
   );


### PR DESCRIPTION
Prevent default react-query re-render on window focus that is causing unnecessary API calls, which is also in turn causing button clicks to rerender the component instead of desired button click action