### PR TITLE
Fix text filter not updating in URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baltimorecounty/react-filter-list",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "A react component that provides standard way to show and filter lists",
   "main": "dist/index.js",
   "module": "dist/index.em.js",

--- a/src/components/FilterList.jsx
+++ b/src/components/FilterList.jsx
@@ -7,7 +7,7 @@ import {
   FormatDateString,
   InitilizeDateValues,
   ShowHideSmallSizeCheckBox,
-  FilterSearchTags
+  FilterSearchTags,
 } from "../common/Filters";
 import useSearchTags from "../hooks/useSearchTags";
 import ApiList from "./ApiList.jsx";
@@ -28,12 +28,12 @@ const FilterList = ({
   renderFilter = (filter, onChange) => (
     <DefaultFilter filter={filter} onChange={onChange} />
   ),
-  renderListHeader = count => (
+  renderListHeader = (count) => (
     <div className="list-header">
       <RecordsMessage count={count} />
     </div>
   ),
-  renderLoadMoreButton = props => <DefaultLoadMoreButton {...props} />,
+  renderLoadMoreButton = (props) => <DefaultLoadMoreButton {...props} />,
   includeInputFilter = false,
   includeDateFilter = false,
   includeClearButton = false,
@@ -95,22 +95,22 @@ const FilterList = ({
   );
 
   useEffect(() => {
-    setFilters(filters => UpdateFilters(filters, location.search));
+    setFilters((filters) => UpdateFilters(filters, location.search));
     setApiEndpoint(buildDefaultEndPoint());
   }, [location.search]);
 
-  const updateQueryString = filter => {
+  const updateQueryString = (filter) => {
     const [base, currentQueryString] = apiEndpoint.split("?");
     const queryString = UpdateQueryString({
       filter,
-      queryString: currentQueryString === undefined ? "" : currentQueryString
+      queryString: currentQueryString === undefined ? "" : currentQueryString,
     });
 
     setApiEndpoint(queryString);
     history.push(location.pathname + queryString);
   };
 
-  const handleFilterChange = changeEvent => {
+  const handleFilterChange = (changeEvent) => {
     const { name, value, checked } = changeEvent;
     if (name == "petType") {
       ShowHideSmallSizeCheckBox(name);
@@ -119,7 +119,7 @@ const FilterList = ({
     updateQueryString({ name, value, checked });
   };
 
-  const handleFilterTextInputChange = query => {
+  const handleFilterTextInputChange = (query) => {
     if (isClear) {
       setIsClear(false);
     }
@@ -132,10 +132,12 @@ const FilterList = ({
 
     // This disables any browser history updates
     // Since a user could possibly update a ton of entries
+    const [base, queryString] = updatedUrl.split("?");
+    history.push(location.pathname + "?" + queryString);
     setApiEndpoint(updatedUrl);
   };
 
-  const handleFromDateChange = date => {
+  const handleFromDateChange = (date) => {
     setFromDate(date);
     if (isDateClear) {
       setIsDateClear(false);
@@ -159,7 +161,7 @@ const FilterList = ({
     setApiEndpoint(updatedUrl);
   };
 
-  const handleToDateChange = date => {
+  const handleToDateChange = (date) => {
     setToDate(date);
     if (isDateClear) {
       setIsDateClear(false);
@@ -202,7 +204,7 @@ const FilterList = ({
 
   const buttonStyles = {
     paddingLeft: "100",
-    paddingRight: "0"
+    paddingRight: "0",
   };
 
   return (
@@ -301,7 +303,7 @@ FilterList.propTypes = {
   /** Placeholder text for the text input filter */
   inputFilterPlaceholder: PropTypes.string,
   /** className attribute for the list container */
-  listContainerClassName: PropTypes.string
+  listContainerClassName: PropTypes.string,
 };
 
 export default withRouter(FilterList);


### PR DESCRIPTION
history.push() line was missing on text filter whereas it is present on the other filters. Added to text filter and bumped package version.